### PR TITLE
Add BLYNK_RETRY_SEND for Spresense LTE board

### DIFF
--- a/src/Adapters/BlynkSpresenseLTE.h
+++ b/src/Adapters/BlynkSpresenseLTE.h
@@ -24,6 +24,7 @@
 #endif
 
 #define BLYNK_SEND_ATOMIC
+#define BLYNK_RETRY_SEND
 
 #include <BlynkApiArduino.h>
 #include <Blynk/BlynkProtocol.h>


### PR DESCRIPTION
<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
Add BLYNK_RETRY_SEND for Spresense LTE board.

### Issues Resolved
Retry in case the send fails.